### PR TITLE
Fix migration load backup

### DIFF
--- a/migration/load-backup.sh
+++ b/migration/load-backup.sh
@@ -1,1 +1,1 @@
-npx wrangler d1 execute v2-ramos --local --file=./migration/.backup.sql
+npx wrangler d1 execute v2-ramos --local --file=./migration/sql/backup.sql


### PR DESCRIPTION
This pr aims to fix an incorrect path for running migration in `load-backup.sh`.

**Before**
`npx wrangler d1 execute v2-ramos --local --file=./migration/.backup.sql`

**After**
`npx wrangler d1 execute v2-ramos --local --file=./migration/sql/backup.sql`