### PR TITLE
Fix/home page search input not working

### DIFF
--- a/src/app/catalogo/page.tsx
+++ b/src/app/catalogo/page.tsx
@@ -1,12 +1,16 @@
 "use client";
 
+import { useSearchParams } from "next/navigation";
 import CoursesTable from "@/components/CoursesTable";
 
 export default function CatalogPage() {
+  const searchParams = useSearchParams();
+  const search = searchParams.get("search") || "";
+
   return (
     <div className="flex justify-center items-center p-4 flex-col w-full max-w-full overflow-hidden">
       <div className="w-full max-w-7xl">
-        <CoursesTable />
+        <CoursesTable externalSearchValue={search} />
       </div>
     </div>
   );

--- a/src/components/CoursesTable.tsx
+++ b/src/components/CoursesTable.tsx
@@ -8,7 +8,11 @@ import { useSetCurrentSemester } from "@/context/semesterCtx";
 import { DataTable } from "@/components/table/DataTable";
 import DataTableSkeleton from "@/components/table/DataTableSkeleton";
 
-export default function CoursesTable() {
+interface CoursesTableProps {
+  externalSearchValue: string;
+}
+
+export default function CoursesTable({ externalSearchValue }: CoursesTableProps) {
   const { data, loading, error } = useNDJSONStream<CourseScore>(
     "https://public.osuc.dev/courses-score.ndjson"
   );
@@ -27,7 +31,7 @@ export default function CoursesTable() {
   return (
     <>
       {loading && <DataTableSkeleton></DataTableSkeleton>}
-      {!loading && <DataTable data={data} />}
+      {!loading && <DataTable data={data} externalSearchValue={externalSearchValue} />}
     </>
   );
 }


### PR DESCRIPTION
This pr aims to make the SearchInput functional in the Home Page.

**Key changes:**
- Add an `externalSearchValue` prop for the component `CoursesTable`.
- Read the query param `search` in the catalog page and pass it to the `CoursesTable` component.

Closes: https://github.com/open-source-uc/BuscaRamos-v2/issues/28