### PR TITLE
fix(reviews): resolve 'La reseña no te pertenece' permission bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ next-env.d.ts
 .open-next/**
 CLAUDE.md
 .backup*
+.agents/

--- a/src/actions/user.reviews.ts
+++ b/src/actions/user.reviews.ts
@@ -66,7 +66,10 @@ export const deleteCourseReview = async (reviewId: number) => {
     };
   }
 
-  if (review.user_id !== user.userId && !hasPermission(user, OsucPermissions.userIsRoot)) {
+  if (
+    String(review.user_id) !== String(user.userId) &&
+    !hasPermission(user, OsucPermissions.userIsRoot)
+  ) {
     return {
       message: "La reseña no te pertenece",
     };
@@ -316,7 +319,10 @@ export const updateCourseReview = async (reviewId: number, formData: FormData) =
     };
   }
 
-  if (review.user_id !== user.userId && !hasPermission(user, OsucPermissions.userIsRoot)) {
+  if (
+    String(review.user_id) !== String(user.userId) &&
+    !hasPermission(user, OsucPermissions.userIsRoot)
+  ) {
     return {
       message: "La reseña no te pertenece",
     };

--- a/src/components/courses/schedules/SectionsCollapsible.tsx
+++ b/src/components/courses/schedules/SectionsCollapsible.tsx
@@ -35,7 +35,15 @@ import QuotaHistorySection, { type QuotaTimeline } from "@/components/courses/Qu
 import { sectionFitsScheduleModuleFilter } from "@/lib/scheduleModuleFilter";
 
 // Semestres válidos extraídos del tipo generado para /data/quota/{sigle}
-export const SEMESTERS = ["2026-2", "2026-1", "2025-2", "2025-1", "2024-3", "2024-2", "2024-1"] as const;
+export const SEMESTERS = [
+  "2026-2",
+  "2026-1",
+  "2025-2",
+  "2025-1",
+  "2024-3",
+  "2024-2",
+  "2024-1",
+] as const;
 export type ValidSemester = (typeof SEMESTERS)[number];
 
 async function fetchSemesterSections(semester: string, sigle: string): Promise<CourseSections> {

--- a/src/components/reviews/Review.tsx
+++ b/src/components/reviews/Review.tsx
@@ -40,7 +40,7 @@ export default function Review({
 }) {
   if (editable === undefined) {
     const { user, isRoot } = use(AuthContext);
-    editable = isRoot || user?.userId === review.user_id;
+    editable = isRoot || String(user?.userId) === String(review.user_id);
   }
 
   return (

--- a/src/components/table/MobileTable.tsx
+++ b/src/components/table/MobileTable.tsx
@@ -1,127 +1,124 @@
 import { calculatePositivePercentage, calculateSentiment } from "@/lib/courseStats";
 import { CourseScore } from "@/types/types";
 import { Table } from "@tanstack/react-table";
-import { useEffect, useRef, useMemo, useCallback, useState } from "react";
 import TableCourseCampuses from "./TableCourseCampuses";
 import { AreaIcon, OpenInFullIcon, Sentiment } from "../icons";
 import { Pill } from "../ui/pill";
 import { Button } from "../ui/button";
 
 interface MobileTableProps {
-    table: Table<CourseScore>;
-    itemsPerPage?: number;
+  table: Table<CourseScore>;
+  itemsPerPage?: number;
 }
 
 export default function MobileTable({ table, itemsPerPage = 10 }: MobileTableProps) {
+  return (
+    <div className="desktop:hidden w-full pt-4">
+      {table.getRowModel().rows?.length ? (
+        <>
+          <div className="grid grid-cols-1 tablet:grid-cols-2 gap-4">
+            {table.getRowModel().rows.map((row) => {
+              const course = row.original;
+              const totalReviews = course.likes + course.superlikes + course.dislikes;
+              const sentimentType = calculateSentiment(
+                course.likes,
+                course.superlikes,
+                course.dislikes
+              );
+              const positivePercentage = calculatePositivePercentage(
+                course.likes,
+                course.superlikes,
+                course.dislikes
+              );
 
-    return (
-        <div className="desktop:hidden w-full pt-4">
-            {table.getRowModel().rows?.length ? (
-                <>
-                    <div className="grid grid-cols-1 tablet:grid-cols-2 gap-4">
-                        {table.getRowModel().rows.map((row) => {
-                            const course = row.original;
-                            const totalReviews = course.likes + course.superlikes + course.dislikes;
-                            const sentimentType = calculateSentiment(
-                                course.likes,
-                                course.superlikes,
-                                course.dislikes
-                            );
-                            const positivePercentage = calculatePositivePercentage(
-                                course.likes,
-                                course.superlikes,
-                                course.dislikes
-                            );
+              return (
+                /* Versión para móvil */
+                <a
+                  key={row.id}
+                  href={`/${course.sigle}`}
+                  className="flex flex-col h-full border-border hover:bg-muted/50 focus:bg-muted/50 focus:ring-ring cursor-pointer rounded-md border p-4 transition-colors focus:ring-2 focus:ring-offset-2 focus:outline-none w-full no-underline"
+                  aria-label={`Ver detalles del curso ${course.sigle} - ${course.name}`}
+                >
+                  {/* Header con sigla y créditos */}
+                  <div className="mb-2 flex items-start justify-between">
+                    <div className="text-foreground text-xs font-medium">{course.sigle}</div>
+                    <div className="text-muted-foreground text-xs">{course.credits} créditos</div>
+                  </div>
 
-                            return (
-                                /* Versión para móvil */
-                                <a
-                                    key={row.id}
-                                    href={`/${course.sigle}`}
-                                    className="flex flex-col h-full border-border hover:bg-muted/50 focus:bg-muted/50 focus:ring-ring cursor-pointer rounded-md border p-4 transition-colors focus:ring-2 focus:ring-offset-2 focus:outline-none w-full no-underline"
-                                    aria-label={`Ver detalles del curso ${course.sigle} - ${course.name}`}
-                                >
-                                    {/* Header con sigla y créditos */}
-                                    <div className="mb-2 flex items-start justify-between">
-                                        <div className="text-foreground text-xs font-medium">{course.sigle}</div>
-                                        <div className="text-muted-foreground text-xs">{course.credits} créditos</div>
-                                    </div>
+                  {/* Nombre del curso */}
+                  <h3 className="text-foreground mb-3 text-lg leading-tight font-semibold wrap-break-word w-full overflow-hidden">
+                    {course.name}
+                  </h3>
 
-                                    {/* Nombre del curso */}
-                                    <h3 className="text-foreground mb-3 text-lg leading-tight font-semibold wrap-break-word w-full overflow-hidden">
-                                        {course.name}
-                                    </h3>
-
-                                    <div className="flex flex-col gap-2">
-                                        {/* Campus */}
-                                        <div className="flex items-center">
-                                            <TableCourseCampuses
-                                                variant="with-icon"
-                                                campus={course.campus || []}
-                                                lastSemester={course.last_semester}
-                                            />
-                                        </div>
-
-                                        {/* Área de Formación General */}
-                                        {Array.isArray(course.area) &&
-                                            course.area.length > 0 &&
-                                            course.area.some((a) => a && String(a).trim() !== "") && (
-                                                <div className="flex items-center">
-                                                    <Pill variant="pink" size="sm" icon={AreaIcon}>
-                                                        {course.area.filter((a) => a && String(a).trim() !== "").join(", ")}
-                                                    </Pill>
-                                                </div>
-                                            )}
-                                        {/* Reseñas con componente Sentiment */}
-                                        <div className="flex items-center justify-between">
-                                            {totalReviews === 0 ? (
-                                                <Sentiment sentiment="question" size="xs" />
-                                            ) : (
-                                                <Sentiment
-                                                    sentiment={sentimentType}
-                                                    size="xs"
-                                                    percentage={positivePercentage}
-                                                    reviewCount={totalReviews}
-                                                    ariaLabel={`${positivePercentage}% de reseñas positivas de ${totalReviews} total`}
-                                                />
-                                            )}
-                                        </div>
-                                    </div>
-                                    <div className="text-muted-foreground mt-auto pt-4 flex flex-row-reverse items-center gap-1 text-xs">
-                                        <OpenInFullIcon className="inline-block h-4 w-4" /> Presiona para ver detalles
-                                    </div>
-                                </a>
-                            );
-                        })}
+                  <div className="flex flex-col gap-2">
+                    {/* Campus */}
+                    <div className="flex items-center">
+                      <TableCourseCampuses
+                        variant="with-icon"
+                        campus={course.campus || []}
+                        lastSemester={course.last_semester}
+                      />
                     </div>
 
-                </>
-            ) : (
-                <div className="text-muted-foreground py-8 text-center">No se encontraron cursos.</div>
-            )}
-            <div className="flex items-center justify-end space-x-2 py-4 w-full">
-                <div className="text-foreground-muted-dark flex-1 text-sm">
-                    {table.getFilteredRowModel().rows.length} cursos encontrados
-                </div>
-                <div className="space-x-2">
-                    <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={() => table.previousPage()}
-                        disabled={!table.getCanPreviousPage()}
-                    >
-                        Anterior
-                    </Button>
-                    <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={() => table.nextPage()}
-                        disabled={!table.getCanNextPage()}
-                    >
-                        Siguiente
-                    </Button>
-                </div>
-            </div>
+                    {/* Área de Formación General */}
+                    {Array.isArray(course.area) &&
+                      course.area.length > 0 &&
+                      course.area.some((a) => a && String(a).trim() !== "") && (
+                        <div className="flex items-center">
+                          <Pill variant="pink" size="sm" icon={AreaIcon}>
+                            {course.area.filter((a) => a && String(a).trim() !== "").join(", ")}
+                          </Pill>
+                        </div>
+                      )}
+                    {/* Reseñas con componente Sentiment */}
+                    <div className="flex items-center justify-between">
+                      {totalReviews === 0 ? (
+                        <Sentiment sentiment="question" size="xs" />
+                      ) : (
+                        <Sentiment
+                          sentiment={sentimentType}
+                          size="xs"
+                          percentage={positivePercentage}
+                          reviewCount={totalReviews}
+                          ariaLabel={`${positivePercentage}% de reseñas positivas de ${totalReviews} total`}
+                        />
+                      )}
+                    </div>
+                  </div>
+                  <div className="text-muted-foreground mt-auto pt-4 flex flex-row-reverse items-center gap-1 text-xs">
+                    <OpenInFullIcon className="inline-block h-4 w-4" /> Presiona para ver detalles
+                  </div>
+                </a>
+              );
+            })}
+          </div>
+        </>
+      ) : (
+        <div className="text-muted-foreground py-8 text-center">No se encontraron cursos.</div>
+      )}
+      <div className="flex items-center justify-end space-x-2 py-4 w-full">
+        <div className="text-foreground-muted-dark flex-1 text-sm">
+          {table.getFilteredRowModel().rows.length} cursos encontrados
         </div>
-    );
+        <div className="space-x-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => table.previousPage()}
+            disabled={!table.getCanPreviousPage()}
+          >
+            Anterior
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => table.nextPage()}
+            disabled={!table.getCanNextPage()}
+          >
+            Siguiente
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
 }


### PR DESCRIPTION
## Description
This PR resolves the authorization bug where legitimate authors receive the error message "La reseña no te pertenece" when trying to edit or delete their own reviews.

The bug is caused by a type mismatch:
- The D1 SQLite database stores `user_id` as an `INTEGER` (evaluated as a `number` in Node/JS).
- The authentication JWT payloads return `user.userId` as a `string`.
- Strict inequality checks (`review.user_id !== user.userId`) evaluated to `true` (e.g. `523 !== "523"`), incorrectly blocking permissions.

Closes #35

## Key Changes
- **Backend (Server Actions):**
  - Updated ownership validation in `deleteCourseReview` and `updateCourseReview` within `src/actions/user.reviews.ts` to convert both IDs to `String` before comparison:
    `String(review.user_id) !== String(user.userId)`
- **Frontend (UI Components):**
  - Updated permission check in `src/components/reviews/Review.tsx` to coerce compared IDs to strings as well, preventing UI render desyncs:
    `editable = isRoot || String(user?.userId) === String(review.user_id)`

## Verification
- Verified locally in dev environment by simulating user authentication through session cookies. The "Edit" and "Delete" actions now execute correctly without permission warnings.
- Ran `npm run lint` and formatted modified files; all checks pass cleanly.
